### PR TITLE
scripts: Fixes gpg issues with deb.torproject.org repository (fix #14)

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -40,9 +40,7 @@ if ! $upgrade; then
 fi
 
 echo 'deb http://deb.torproject.org/torproject.org jessie main' | sudo tee "/etc/apt/sources.list.d/torproject.list"
-
-gpg --keyserver keys.gnupg.net --recv 886DDD89
-gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | sudo apt-key add -
+sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 0xee8cbc9e886ddd89
 
 # Install packages
 packages='tor php5-fpm'

--- a/scripts/remove
+++ b/scripts/remove
@@ -45,6 +45,7 @@ sudo systemctl reload nginx
 sudo rm -rf /var/www/torclient/
 
 sudo rm -rf /etc/apt/sources.list.d/torproject.list
+sudo apt-key del 0xee8cbc9e886ddd89
 sudo apt-get update
 
 exit 0


### PR DESCRIPTION
- install: No need to initialize a specific GPG keyring for install
  user, let directly handle the key with apt-key.
- remove: Clean missing gpg key (from apt keyring).
